### PR TITLE
Adding three fields to clockwork.toml

### DIFF
--- a/templates/clockwork.toml.j2
+++ b/templates/clockwork.toml.j2
@@ -35,3 +35,23 @@ allocations={{ cluster.allocations }}
 {% endif %}
 timezone="{{ cluster.timezone }}"
 {% endfor %}
+{% if cluster.remote_user %}
+remote_user="{{ cluster.remote_user }}"
+{% else %}
+remote_user=""
+{% endif %}
+{% if cluster.remote_hostname %}
+remote_hostname="{{ cluster.remote_hostname }}"
+{% else %}
+remote_hostname=""
+{% endif %}
+{% if cluster.remote_hostname %}
+remote_hostname="{{ cluster.remote_hostname }}"
+{% else %}
+remote_hostname=""
+{% endif %}
+{% if cluster.sacct_enabled %}
+sacct_enabled="{{ cluster.sacct_enabled }}"
+{% else %}
+sacct_enabled=false
+{% endif %}


### PR DESCRIPTION
These fields are going to be used for calling `sacct` through SSH. These fields are already in the `hosts.yml` but they don't make it to `/etc/clockwork/clockwork.toml` at the moment and that means that we cannot use them. This commit will fix that.

This related to cw204 branch of Clockwork, and in turn to `https://github.com/mila-iqia/clockwork/pull/88`.